### PR TITLE
Use ensure ascii

### DIFF
--- a/text_analysis/main/views.py
+++ b/text_analysis/main/views.py
@@ -28,7 +28,7 @@ def reading(request):
         'items': mecab_utils.reading_sentence(sentence, nbest_num),
     }
 
-    return JsonResponse(ret)
+    return JsonResponse(ret, json_dumps_params={'ensure_ascii': False, 'separators': (',', ':')})
 
 
 @cache_control(max_age=86400)
@@ -52,7 +52,7 @@ def parse(request):
         'items': mecab_utils.parse_sentence(sentence, nbest_num),
     }
 
-    return JsonResponse(ret)
+    return JsonResponse(ret, json_dumps_params={'ensure_ascii': False, 'separators': (',', ':')})
 
 
 def handler400(request):


### PR DESCRIPTION
* Use UTF-8 instead of `\uXXXX` characters.
* reduce space

before
```
{"input_sentence": "\u4eca\u65e5\u306f\u826f\u3044\u5929\u6c17\u3060", ...
```

after
```
{"input_sentence":"今日は良い天気だ", ...
```